### PR TITLE
IP Authentication

### DIFF
--- a/esmond/admin/admin.py
+++ b/esmond/admin/admin.py
@@ -33,4 +33,4 @@ admin.site.register(PSMetadata)
 admin.site.register(PSPointToPointSubject)
 admin.site.register(PSEventTypes)
 admin.site.register(PSMetadataParameters)
-
+admin.site.register(UserIpAddress)

--- a/esmond/api/auth.py
+++ b/esmond/api/auth.py
@@ -3,6 +3,7 @@ import json
 from esmond.api import ANON_LIMIT
 from esmond.api.models import UserIpAddress
 
+from django.db.utils import DatabaseError
 from tastypie.authorization import Authorization
 from tastypie.authentication import Authentication, ApiKeyAuthentication
 from tastypie.exceptions import NotFound, BadRequest, Unauthorized
@@ -42,15 +43,14 @@ class IPAuthentication(Authentication):
         #sort so that most specific subnet is at top of list
         userip = []
         try:
-            userip = UserIpAddress.objects.filter(ip__net_contains_or_equals=remoteip).order_by("-ip");
-        except DatabaseError, e:
+            userip = UserIpAddress.objects.filter(ip__net_contains_or_equals=remoteip).order_by("-ip")
+            if userip:
+                request.user = userip[0].user
+                return True
+        except DatabaseError:
             #if you are here then the backend doesn't support IP operations, moving on
-            return False
+            pass
             
-        if userip:
-            request.user = userip[0].user
-            return True
-        
         return False
     
     def get_identifier(self, request):

--- a/esmond/api/auth.py
+++ b/esmond/api/auth.py
@@ -40,7 +40,7 @@ class IPAuthentication(Authentication):
     def is_authenticated(self, request, **kwargs):
         remoteip = request.META['REMOTE_ADDR']
         print "remote IP %s" % remoteip
-        userip = UserIpAddress.objects.filter(ip__net_contains=remoteip);
+        userip = UserIpAddress.objects.filter(ip__net_contains_or_equals=remoteip).order_by("-ip");
         if userip:
             print "Authenticated to %s as %s" % (userip[0].ip, userip[0].user)
             request.user = userip[0].user

--- a/esmond/api/auth.py
+++ b/esmond/api/auth.py
@@ -42,8 +42,8 @@ class IPAuthentication(Authentication):
         print "remote IP %s" % remoteip
         userip = UserIpAddress.objects.filter(ip__contains=remoteip);
         if userip:
-            print "Authenticated to %s as %s" % (userip.ip, userip.user.username)
-            request.user = userip.user
+            print "Authenticated to %s as %s" % (userip[0].ip, userip[0].user)
+            request.user = userip[0].user
             return True
         
         print "Unable to authenticate %s" % remoteip

--- a/esmond/api/auth.py
+++ b/esmond/api/auth.py
@@ -40,7 +40,13 @@ class IPAuthentication(Authentication):
     def is_authenticated(self, request, **kwargs):
         remoteip = request.META['REMOTE_ADDR']
         #sort so that most specific subnet is at top of list
-        userip = UserIpAddress.objects.filter(ip__net_contains_or_equals=remoteip).order_by("-ip");
+        userip = []
+        try:
+            userip = UserIpAddress.objects.filter(ip__net_contains_or_equals=remoteip).order_by("-ip");
+        except DatabaseError, e:
+            #if you are here then the backend doesn't support IP operations, moving on
+            return False
+            
         if userip:
             request.user = userip[0].user
             return True

--- a/esmond/api/auth.py
+++ b/esmond/api/auth.py
@@ -1,7 +1,7 @@
 import json
 
 from esmond.api import ANON_LIMIT
-from esmond.models import UserIpAddress
+from esmond.api.models import UserIpAddress
 
 from tastypie.authorization import Authorization
 from tastypie.authentication import Authentication, ApiKeyAuthentication

--- a/esmond/api/auth.py
+++ b/esmond/api/auth.py
@@ -40,7 +40,7 @@ class IPAuthentication(Authentication):
     def is_authenticated(self, request, **kwargs):
         remoteip = request.META['REMOTE_ADDR']
         print "remote IP %s" % remoteip
-        userip = UserIpAddress.objects.filter(ip__contains=remoteip);
+        userip = UserIpAddress.objects.filter(ip__net_contains=remoteip);
         if userip:
             print "Authenticated to %s as %s" % (userip[0].ip, userip[0].user)
             request.user = userip[0].user

--- a/esmond/api/auth.py
+++ b/esmond/api/auth.py
@@ -36,17 +36,15 @@ class AnonymousGetElseApiAuthentication(ApiKeyAuthentication):
                     self).get_identifier(request)
 
 class IPAuthentication(Authentication):
-    
+    """Class to aunthenticate based on client IP. Associates IP with a django user account"""
     def is_authenticated(self, request, **kwargs):
         remoteip = request.META['REMOTE_ADDR']
-        print "remote IP %s" % remoteip
+        #sort so that most specific subnet is at top of list
         userip = UserIpAddress.objects.filter(ip__net_contains_or_equals=remoteip).order_by("-ip");
         if userip:
-            print "Authenticated to %s as %s" % (userip[0].ip, userip[0].user)
             request.user = userip[0].user
             return True
         
-        print "Unable to authenticate %s" % remoteip
         return False
     
     def get_identifier(self, request):

--- a/esmond/api/management/commands/add_user_ip_address.py
+++ b/esmond/api/management/commands/add_user_ip_address.py
@@ -1,0 +1,64 @@
+import sys
+import datetime
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.contrib.auth.models import User, Group, Permission
+
+from tastypie.models import ApiKey
+from esmond.api.models import UserIpAddress
+
+class Command(BaseCommand):
+    args = 'user ip1 [ip2...]'
+    help = 'Associate IP subnet(s) with a user account'
+
+    def handle(self, *args, **options):
+        self.options = options
+
+        if len(args) < 2:
+            print >>sys.stderr, "takes at least two arguments: %s" % self.args
+            return
+
+        user = args[0]
+
+        u = None
+
+        try:
+            u = User.objects.get(username=user)
+            print 'User {0} exists'.format(user)
+        except User.DoesNotExist:
+            print 'User {0} does not exist - creating'.format(user)
+            u = User(username=user, is_staff=True)
+            u.save()
+
+        print 'Setting metadata POST permissions.'
+        for model_name in ['psmetadata', 'pspointtopointsubject', 'pseventtypes', 'psmetadataparameters', 'psnetworkelementsubject']:
+            for perm_name in ['add', 'change', 'delete']:
+                perm = Permission.objects.get(codename='{0}_{1}'.format(perm_name, model_name))
+                print perm
+                u.user_permissions.add(perm)
+        
+        print 'Setting timeseries permissions.'
+        for resource in ['timeseries']:
+            for perm_name in ['view', 'add', 'change', 'delete']:
+                perm = Permission.objects.get(
+                    codename="esmond_api.{0}_{1}".format(perm_name, resource))
+                u.user_permissions.add(perm)
+                
+        u.save()
+        
+        for ip_addr in args[1:]:
+            try:
+                userip = UserIpAddress.objects.get(ip=ip_addr)
+                print 'IP {0} already assigned to {1}, skipping creation'.format(userip.ip, userip.user)
+            except ApiKey.DoesNotExist:
+                print 'Creating entry for IP {0} belonging to {1}'.format(ip_addr, user)
+                userip = UserIpAddress(ip=ip_addr, user=u)
+                userip.save()
+        
+
+        key = ApiKey.objects.get(user=u)
+
+        print 'Key: {0}'.format(key)
+
+        

--- a/esmond/api/management/commands/add_user_ip_address.py
+++ b/esmond/api/management/commands/add_user_ip_address.py
@@ -57,8 +57,4 @@ class Command(BaseCommand):
                 userip.save()
         
 
-        key = ApiKey.objects.get(user=u)
-
-        print 'Key: {0}'.format(key)
-
         

--- a/esmond/api/management/commands/add_user_ip_address.py
+++ b/esmond/api/management/commands/add_user_ip_address.py
@@ -51,7 +51,7 @@ class Command(BaseCommand):
             try:
                 userip = UserIpAddress.objects.get(ip=ip_addr)
                 print 'IP {0} already assigned to {1}, skipping creation'.format(userip.ip, userip.user)
-            except ApiKey.DoesNotExist:
+            except UserIpAddress.DoesNotExist:
                 print 'Creating entry for IP {0} belonging to {1}'.format(ip_addr, user)
                 userip = UserIpAddress(ip=ip_addr, user=u)
                 userip.save()

--- a/esmond/api/models.py
+++ b/esmond/api/models.py
@@ -4,6 +4,7 @@ import datetime
 
 from django.contrib.auth.models import User, Permission
 from django.contrib.contenttypes.models import ContentType
+from netfields import CidrAddressField, NetManager
 
 from esmond.util import datetime_to_unixtime, remove_metachars, max_datetime, atencode
 
@@ -530,9 +531,10 @@ class PSMetadataParameters(models.Model):
         return "%s" % (self.parameter_key)
 
 class UserIpAddress(models.Model):
-    ip = models.GenericIPAddressField(unique=True, db_index=True)
+    ip = CidrAddressField(unique=True, db_index=True)
     user = models.ForeignKey(User, related_name='user')
-
+    objects = NetManager()
+    
     class Meta:
         db_table = "useripaddress"
     

--- a/esmond/api/models.py
+++ b/esmond/api/models.py
@@ -465,7 +465,8 @@ class PSMetadata(models.Model):
     
     class Meta:
         db_table = "ps_metadata"
-    
+        ordering = ["metadata_key"] #gives consistent ordering
+        
     def __unicode__(self):
         return self.metadata_key
     

--- a/esmond/api/models.py
+++ b/esmond/api/models.py
@@ -2,7 +2,7 @@ from django.db import models
 from django.utils.timezone import now
 import datetime
 
-from django.contrib.auth.models import Permission
+from django.contrib.auth.models import User, Permission
 from django.contrib.contenttypes.models import ContentType
 
 from esmond.util import datetime_to_unixtime, remove_metachars, max_datetime, atencode
@@ -529,4 +529,14 @@ class PSMetadataParameters(models.Model):
     def __unicode__(self):
         return "%s" % (self.parameter_key)
 
+class UserIpAddress(models.Model):
+    ip = models.IPAddressField(unique=True, db_index=True)
+    user = models.ForeignKey(User, related_name='user')
 
+    class Meta:
+        db_table = "useripaddress"
+    
+    def __unicode__(self):
+        return self.ip
+
+    =

--- a/esmond/api/models.py
+++ b/esmond/api/models.py
@@ -537,6 +537,8 @@ class UserIpAddress(models.Model):
     
     class Meta:
         db_table = "useripaddress"
+        verbose_name = "User IP Address"
+        verbose_name_plural = "User IP Addresses"
     
     def __unicode__(self):
-        return self.ip
+        return "%s - %s" % (self.ip, self.user)

--- a/esmond/api/models.py
+++ b/esmond/api/models.py
@@ -538,5 +538,3 @@ class UserIpAddress(models.Model):
     
     def __unicode__(self):
         return self.ip
-
-    =

--- a/esmond/api/models.py
+++ b/esmond/api/models.py
@@ -530,7 +530,7 @@ class PSMetadataParameters(models.Model):
         return "%s" % (self.parameter_key)
 
 class UserIpAddress(models.Model):
-    ip = models.IPAddressField(unique=True, db_index=True)
+    ip = models.GenericIPAddressField(unique=True, db_index=True)
     user = models.ForeignKey(User, related_name='user')
 
     class Meta:

--- a/esmond/api/perfsonar/api.py
+++ b/esmond/api/perfsonar/api.py
@@ -148,6 +148,10 @@ def handle_time_filters(filters):
 # Resource classes
 class CustomModelResource(ModelResource):
     
+    class Meta:
+        authentication = MultiAuthentication(AnonymousGetElseApiAuthentication(), IPAuthentication())
+        authorization = DjangoAuthorization()
+        
     def __init__(self, api_name=None):
         self.fields = self.base_fields
 
@@ -157,12 +161,10 @@ class CustomModelResource(ModelResource):
 class PSEventTypesResource(CustomModelResource):
     psmetadata = fields.ToOneField('esmond.api.perfsonar.api.PSArchiveResource', 'metadata', null=True, blank=True)
      
-    class Meta:
+    class Meta(CustomModelResource.Meta):
         queryset=PSEventTypes.objects.all()
         resource_name = 'event-type'
         allowed_methods = ['get', 'post']
-        authentication = MultiAuthentication(IPAuthentication(), AnonymousGetElseApiAuthentication())
-        authorization = DjangoAuthorization()
         excludes = ['id']
         filtering = {
             "event_type": ['exact'],  
@@ -306,13 +308,11 @@ class PSEventTypesResource(CustomModelResource):
         return super(CustomModelResource, self).build_filters(formatted_filters)
             
 class PSEventTypeSummaryResource(PSEventTypesResource):
-    class Meta:
+    class Meta(CustomModelResource.Meta):
         queryset=PSEventTypes.objects.all()
         resource_name = 'summary'
         allowed_methods = ['get']
         excludes = ['id']
-        authentication = MultiAuthentication(IPAuthentication(), AnonymousGetElseApiAuthentication())
-        authorization = DjangoAuthorization()
         filtering = {
             "event_type": ['exact'],  
             "summary_type": ['exact'],
@@ -332,12 +332,10 @@ class PSEventTypeSummaryResource(PSEventTypesResource):
 class PSPointToPointSubjectResource(CustomModelResource):
     psmetadata = fields.ToOneField('esmond.api.perfsonar.api.PSArchiveResource', 'metadata', null=True, blank=True)
     
-    class Meta:
+    class Meta(CustomModelResource.Meta):
         queryset=PSPointToPointSubject.objects.all()
         resource_name = 'p2p_subject'
         allowed_methods = ['get', 'post']
-        authentication = MultiAuthentication(IPAuthentication(), AnonymousGetElseApiAuthentication())
-        authorization = DjangoAuthorization()
         excludes = ['id']
         filtering = {
             "source": ['exact', 'in'],  
@@ -362,12 +360,10 @@ class PSPointToPointSubjectResource(CustomModelResource):
 class PSNetworkElementSubjectResource(CustomModelResource):
     psmetadata = fields.ToOneField('esmond.api.perfsonar.api.PSArchiveResource', 'metadata', null=True, blank=True)
     
-    class Meta:
+    class Meta(CustomModelResource.Meta):
         queryset=PSNetworkElementSubject.objects.all()
         resource_name = 'networkelement_subject'
         allowed_methods = ['get', 'post']
-        authentication = MultiAuthentication(IPAuthentication(), AnonymousGetElseApiAuthentication())
-        authorization = DjangoAuthorization()
         excludes = ['id']
         filtering = {
             "source": ['exact', 'in'],  
@@ -390,12 +386,10 @@ class PSNetworkElementSubjectResource(CustomModelResource):
 class PSMetadataParametersResource(CustomModelResource):
     psmetadata = fields.ToOneField('esmond.api.perfsonar.api.PSArchiveResource', 'metadata', null=True, blank=True)
     
-    class Meta:
+    class Meta(CustomModelResource.Meta):
         queryset=PSMetadataParameters.objects.all()
         resource_name = 'metadata-parameters'
         allowed_methods = ['get', 'post']
-        authentication = MultiAuthentication(IPAuthentication(), AnonymousGetElseApiAuthentication())
-        authorization = DjangoAuthorization()
         excludes = ['id']
     
     def get_resource_uri(self, bundle_or_obj=None):
@@ -407,7 +401,7 @@ class PSArchiveResource(CustomModelResource):
     networkelement_subject = fields.ToOneField(PSNetworkElementSubjectResource, 'psnetworkelementsubject', related_name='psmetadata', full=True, null=True, blank=True)
     md_parameters = fields.ToManyField(PSMetadataParametersResource, 'psmetadataparameters', related_name='psmetadata', full=True, null=True, blank=True)
     
-    class Meta:
+    class Meta(CustomModelResource.Meta):
         queryset=PSMetadata.objects.select_related('pspointtopointsubject').prefetch_related('pseventtypes', 'psmetadataparameters').all()
         always_return_data = True
         resource_name = 'archive'
@@ -415,8 +409,6 @@ class PSArchiveResource(CustomModelResource):
         allowed_methods = ['get', 'post']
         excludes = ['id']
         limit = 0
-        authentication = MultiAuthentication(IPAuthentication(), AnonymousGetElseApiAuthentication())
-        authorization = DjangoAuthorization()
         filtering = {
             "metadata_key": ['exact'],
             "subject_type": ['exact'],
@@ -849,10 +841,9 @@ class PSTimeSeriesObject(object):
         
 class PSTimeSeriesResource(Resource):
     
-    class Meta:
+    class Meta(CustomModelResource.Meta):
         resource_name = 'pstimeseries'
         allowed_methods = ['get', 'post']
-        authentication = MultiAuthentication(IPAuthentication(), AnonymousGetElseApiAuthentication())
         authorization = EsmondAuthorization('timeseries')
         limit = 0
         max_limit = 0
@@ -1059,10 +1050,9 @@ class PSTimeSeriesResource(Resource):
         log.debug("action=create_timeseries.end status=0")
                   
 class PSBulkTimeSeriesResource(PSTimeSeriesResource):
-    class Meta:
+    class Meta(CustomModelResource.Meta):
         resource_name = 'bulkpstimeseries'
         allowed_methods = ['post']
-        authentication = MultiAuthentication(IPAuthentication(), AnonymousGetElseApiAuthentication())
         authorization = EsmondAuthorization('timeseries')
         limit = 0
         max_limit = 0

--- a/esmond/api/perfsonar/api.py
+++ b/esmond/api/perfsonar/api.py
@@ -1,5 +1,5 @@
 from calendar import timegm
-from esmond.api.auth import AnonymousGetElseApiAuthentication, EsmondAuthorization
+from esmond.api.auth import AnonymousGetElseApiAuthentication, EsmondAuthorization, IPAuthentication
 from esmond.api.models import PSMetadata, PSPointToPointSubject, PSEventTypes, PSMetadataParameters, PSNetworkElementSubject
 from esmond.api.perfsonar.types import *
 from esmond.cassandra import KEY_DELIMITER, CASSANDRA_DB, AGG_TYPES, ConnectionException, RawRateData, BaseRateBin, RawData, AggregationBin
@@ -14,6 +14,7 @@ from socket import getaddrinfo, AF_INET, AF_INET6, SOL_TCP, SOCK_STREAM
 from string import join
 from tastypie import fields
 from tastypie.api import Api
+from tastypie.authentication import MultiAuthentication
 from tastypie.authorization import Authorization, DjangoAuthorization
 from tastypie.bundle import Bundle
 from tastypie.http import HttpConflict
@@ -160,7 +161,7 @@ class PSEventTypesResource(CustomModelResource):
         queryset=PSEventTypes.objects.all()
         resource_name = 'event-type'
         allowed_methods = ['get', 'post']
-        authentication = AnonymousGetElseApiAuthentication()
+        authentication = MultiAuthentication(IPAuthentication(), AnonymousGetElseApiAuthentication())
         authorization = DjangoAuthorization()
         excludes = ['id']
         filtering = {
@@ -310,7 +311,7 @@ class PSEventTypeSummaryResource(PSEventTypesResource):
         resource_name = 'summary'
         allowed_methods = ['get']
         excludes = ['id']
-        authentication = AnonymousGetElseApiAuthentication()
+        authentication = MultiAuthentication(IPAuthentication(), AnonymousGetElseApiAuthentication())
         authorization = DjangoAuthorization()
         filtering = {
             "event_type": ['exact'],  
@@ -335,7 +336,7 @@ class PSPointToPointSubjectResource(CustomModelResource):
         queryset=PSPointToPointSubject.objects.all()
         resource_name = 'p2p_subject'
         allowed_methods = ['get', 'post']
-        authentication = AnonymousGetElseApiAuthentication()
+        authentication = MultiAuthentication(IPAuthentication(), AnonymousGetElseApiAuthentication())
         authorization = DjangoAuthorization()
         excludes = ['id']
         filtering = {
@@ -365,7 +366,7 @@ class PSNetworkElementSubjectResource(CustomModelResource):
         queryset=PSNetworkElementSubject.objects.all()
         resource_name = 'networkelement_subject'
         allowed_methods = ['get', 'post']
-        authentication = AnonymousGetElseApiAuthentication()
+        authentication = MultiAuthentication(IPAuthentication(), AnonymousGetElseApiAuthentication())
         authorization = DjangoAuthorization()
         excludes = ['id']
         filtering = {
@@ -393,7 +394,7 @@ class PSMetadataParametersResource(CustomModelResource):
         queryset=PSMetadataParameters.objects.all()
         resource_name = 'metadata-parameters'
         allowed_methods = ['get', 'post']
-        authentication = AnonymousGetElseApiAuthentication()
+        authentication = MultiAuthentication(IPAuthentication(), AnonymousGetElseApiAuthentication())
         authorization = DjangoAuthorization()
         excludes = ['id']
     
@@ -414,7 +415,7 @@ class PSArchiveResource(CustomModelResource):
         allowed_methods = ['get', 'post']
         excludes = ['id']
         limit = 0
-        authentication = AnonymousGetElseApiAuthentication()
+        authentication = MultiAuthentication(IPAuthentication(), AnonymousGetElseApiAuthentication())
         authorization = DjangoAuthorization()
         filtering = {
             "metadata_key": ['exact'],
@@ -851,7 +852,7 @@ class PSTimeSeriesResource(Resource):
     class Meta:
         resource_name = 'pstimeseries'
         allowed_methods = ['get', 'post']
-        authentication = AnonymousGetElseApiAuthentication()
+        authentication = MultiAuthentication(IPAuthentication(), AnonymousGetElseApiAuthentication())
         authorization = EsmondAuthorization('timeseries')
         limit = 0
         max_limit = 0
@@ -1061,7 +1062,7 @@ class PSBulkTimeSeriesResource(PSTimeSeriesResource):
     class Meta:
         resource_name = 'bulkpstimeseries'
         allowed_methods = ['post']
-        authentication = AnonymousGetElseApiAuthentication()
+        authentication = MultiAuthentication(IPAuthentication(), AnonymousGetElseApiAuthentication())
         authorization = EsmondAuthorization('timeseries')
         limit = 0
         max_limit = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 sphinx
 django-discover-runner
+django-netfields
 -e hg+https://bitbucket.org/jdugan/dlnetsnmp#egg=DLNetSNMP
 -e .
 -e ./esmond_client/


### PR DESCRIPTION
I added support for authentication using the client IP address to the perfSONAR API. In theory it shouldn't affect any of the SNMP code (though if you did want to use the IPAuthentication class in the SNMP stuff it should "just work"). A couple things worth highlighting:

- Right now it's configured as a fallback if no API key is present, so not a replacement, just another option.

- It adds a dependency on django-netfields so it can leverage some of the IP subnet functions supported by postgresql. The library is in PyPI, seems like its been around a few years and was updated in the last 6 months so seems pretty solid. It's also not doing a whole lot, so hopefully should be a good citizen. 

- The code really just maps IP subnets to existing django users so its not changing the paradigm too much. Instead of pulling user/API key out of the HTTP headers, it's looking at the IP in the client's IP headers then mapping to the user based on that. You can add a user by running "python esmond/manage.py add_user_ip_address <username> <ip-subnet1> [ip-subnet2…]. Example: python esmond/manage.py add_user_ip_address alake 192.168.56.0/24

- It should work with IPv4 and IPv6
