### PR TITLE
Increase the number of processes used by WSGI.

### DIFF
--- a/rpm/config_files/apache-esmond.conf
+++ b/rpm/config_files/apache-esmond.conf
@@ -4,7 +4,7 @@ WSGIPythonHome /opt/esmond
 WSGIPassAuthorization On
 WSGISocketPrefix run/wsgi
 
-WSGIDaemonProcess apache python-path=/opt/esmond/esmond:/opt/esmond/lib/python2.7:/opt/esmond/lib/python2.7/site-packages home=/opt/esmond processes=3 threads=15
+WSGIDaemonProcess apache python-path=/opt/esmond/esmond:/opt/esmond/lib/python2.7:/opt/esmond/lib/python2.7/site-packages home=/opt/esmond processes=10 threads=5
 WSGIProcessGroup apache
 
 <Directory /opt/esmond/esmond>


### PR DESCRIPTION
As the Python GIL performs poorly under heavy threading, by
decreasing the number of threads-per-process and doubling the number
of processes, we saw a doubling of the throughput for the OSG
data store.