### PR TITLE
perfsonar query API: fix QueryLimitException

### DIFF
--- a/esmond/api/client/perfsonar/query.py
+++ b/esmond/api/client/perfsonar/query.py
@@ -67,12 +67,7 @@ class ApiConnectWarning(Warning):
 
 class QueryLimitException(Exception):
     """Custom QueryLimit exception"""
-    def __init__(self, value):
-        # pylint: disable=super-init-not-called
-        self.value = value
-
-    def __str__(self):
-        return repr(self.value)
+    pass
 
 
 class QueryLimitWarning(Warning):


### PR DESCRIPTION
Remove constructor argument that is not use anywhere. When the exception
was used, the absence of the argument in the raise call  was making the
error message weird.