### PR TITLE
Fix poller and reinstate init scripts

### DIFF
--- a/esmond/persist.py
+++ b/esmond/persist.py
@@ -1356,6 +1356,8 @@ def espersistd():
     worker sub-processes.
 
     """
+    django.setup()
+
     argv = sys.argv
     oparse = get_opt_parser(default_config_file=get_config_path())
     oparse.add_option("-r", "--role", dest="role", default="manager")

--- a/esmond/poll.py
+++ b/esmond/poll.py
@@ -965,6 +965,8 @@ def espoll():
 
     device_name, oidset_name = args[1:]
 
+    django.setup()
+
     try:
         config = get_config(opts.config_file, opts)
     except ConfigError, e:
@@ -1026,6 +1028,8 @@ def espolld():
     argv = sys.argv
     oparse = get_opt_parser(default_config_file=get_config_path())
     (opts, args) = oparse.parse_args(args=argv)
+
+    django.setup()
 
     try:
         config = get_config(opts.config_file, opts)

--- a/rpm/init_scripts/espersistd
+++ b/rpm/init_scripts/espersistd
@@ -1,0 +1,94 @@
+#!/bin/sh 
+#
+# $Id: ndt 206 2008-09-09 13:05:01Z throck $
+#
+# chkconfig: 2345 55 25
+# description: Starts the Esmond Collector
+
+# source function library
+. /etc/rc.d/init.d/functions
+
+# get local NDT configuration
+if [ -f /etc/sysconfig/esmond ];then
+        . /etc/sysconfig/esmond
+fi
+
+PROGRAM=espersistd
+
+# defaults, if not specified in local config
+[ "$PID_DIR" = "" ] && PID_DIR="/var/run/esmond"
+[ "$ESMOND_USER" = "" ] && ESMOND_USER="esmond"
+[ "$ESMOND_ROOT" = "" ] && ESMOND_ROOT="/usr/lib/esmond"
+[ "$CONFIG_FILE" = "" ] && CONFIG_FILE="${ESMOND_CONF}"
+[ "$DJANGO_SETTINGS_MODULE" = "" ] && DJANGO_SETTINGS_MODULE="esmond.settings"
+
+export ESMOND_ROOT
+export DJANGO_SETTINGS_MODULE
+
+[ -f $ESMOND_ROOT/bin/$PROGRAM ] || exit -1
+[ -d "$PID_DIR" ] || exit -1
+
+# Verify that memcached is running
+`/etc/init.d/memcached status 2>&1 > /dev/null`
+[ $? == 0 ] || exit -1
+
+RETVAL=0
+
+start ()
+{
+   cnt=`ps auxw | grep $PROGRAM | grep -v grep | grep -v sh | wc -l`
+   if [ $cnt = 0 ]
+   then
+      echo -n "Starting $PROGRAM:"
+      su -c "$ESMOND_ROOT/bin/$PROGRAM -f $CONFIG_FILE -p $PID_DIR" $ESMOND_USER
+      RETVAL=$?
+      if [ $RETVAL = 0 ]
+      then 
+	success
+        touch /var/lock/subsys/$PROGRAM
+      else
+	failure
+      fi
+      echo
+   else
+       echo "$PROGRAM is already running"
+   fi
+}
+
+stop ()
+{
+   echo -n "Stopping $PROGRAM:"
+   killproc $PROGRAM -TERM
+   RETVAL=$?
+   echo
+   [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/$PROGRAM
+}
+
+rhstatus() {
+	status $PROGRAM
+}
+
+restart() {
+	stop
+	start
+}
+
+case "$1" in
+start)
+   start
+   ;;
+stop)
+   stop
+   ;;
+status)
+   rhstatus
+   ;;
+restart|reload)
+   restart
+   ;;
+*)
+   echo $"Usage: $0 {start|stop|status|restart}"
+   exit 1
+esac
+
+exit $?

--- a/rpm/init_scripts/espolld
+++ b/rpm/init_scripts/espolld
@@ -1,0 +1,90 @@
+#!/bin/sh 
+#
+# $Id: ndt 206 2008-09-09 13:05:01Z throck $
+#
+# chkconfig: 2345 55 25
+# description: Starts the Esmond Collector
+
+# source function library
+. /etc/rc.d/init.d/functions
+
+# get local NDT configuration
+if [ -f /etc/sysconfig/esmond ];then
+        . /etc/sysconfig/esmond
+fi
+
+PROGRAM=espolld
+
+# defaults, if not specified in local config
+[ "$PID_DIR" = "" ] && PID_DIR="/var/run/esmond"
+[ "$ESMOND_USER" = "" ] && ESMOND_USER="esmond"
+[ "$ESMOND_ROOT" = "" ] && ESMOND_ROOT="/usr/lib/esmond"
+[ "$CONFIG_FILE" = "" ] && CONFIG_FILE="/etc/esmond/esmond.conf"
+[ "$DJANGO_SETTINGS_MODULE" = "" ] && DJANGO_SETTINGS_MODULE="esmond.settings"
+
+export ESMOND_ROOT
+export DJANGO_SETTINGS_MODULE
+
+[ -f $ESMOND_ROOT/bin/$PROGRAM ] || exit -1
+[ -d "$PID_DIR" ] || exit -1
+
+RETVAL=0
+
+start ()
+{
+   cnt=`ps auxw | grep $PROGRAM | grep -v grep | grep -v sh | wc -l`
+   if [ $cnt = 0 ]
+   then
+      echo -n "Starting $PROGRAM:"
+      su -c "$ESMOND_ROOT/bin/$PROGRAM -f $CONFIG_FILE -p $PID_DIR" $ESMOND_USER
+      RETVAL=$?
+      if [ $RETVAL = 0 ]
+      then 
+	success
+        touch /var/lock/subsys/$PROGRAM
+      else
+	failure
+      fi
+      echo
+   else
+       echo "$PROGRAM is already running"
+   fi
+}
+
+stop ()
+{
+   echo -n "Stopping $PROGRAM:"
+   killproc $PROGRAM -TERM
+   RETVAL=$?
+   echo
+   [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/$PROGRAM
+}
+
+rhstatus() {
+	status $PROGRAM
+}
+
+restart() {
+	stop
+	start
+}
+
+case "$1" in
+start)
+   start
+   ;;
+stop)
+   stop
+   ;;
+status)
+   rhstatus
+   ;;
+restart|reload)
+   restart
+   ;;
+*)
+   echo $"Usage: $0 {start|stop|status|restart}"
+   exit 1
+esac
+
+exit $?


### PR DESCRIPTION
This fixes #49.

This also resurrected the init script for espolld and espersistd. They are slightly tweaked from the ones that were deleted in 72020e13e384161a28920c0ff15aab188953b6c5

@arlake228 I probably need your help to get them back into the RPM build process. (Assuming that's OK with you.)  Once that's done then we can look into merging this.