### PR TITLE
Fix sanity check for q_params time-start >= time-end

### DIFF
--- a/esmond/api/client/perfsonar/query.py
+++ b/esmond/api/client/perfsonar/query.py
@@ -181,7 +181,8 @@ class NodeInfo(object):
 
                 # sanity check - this should not happen other than the unlikely
                 # scenario where the final request results is exactly == LIMIT
-                if q_params['time-start'] >= q_params['time-end']:
+                if 'time-end' in q_params and \
+                        q_params['time-start'] >= q_params['time-end']:
                     self.warn('time start >= time end - exiting query loop')
                     break
             else:


### PR DESCRIPTION
We were getting a KeyError when time-end is not defined - and it is
no always defined.