### PR TITLE
Adds support for CORS from all hosts, globally. There may be a more fine-grained way of doing this.

### DIFF
--- a/rpm/config_files/apache-esmond.conf
+++ b/rpm/config_files/apache-esmond.conf
@@ -8,6 +8,7 @@ WSGIDaemonProcess apache python-path=/usr/lib/esmond/esmond:/usr/lib/esmond/lib/
 WSGIProcessGroup apache
 
 <Directory /usr/lib/esmond/esmond>
+Header set Access-Control-Allow-Origin "*"
 <Files wsgi.py>
 SetEnv ESMOND_ROOT /usr/lib/esmond
 SetEnv ESMOND_CONF /etc/esmond/esmond.conf
@@ -24,6 +25,7 @@ AuthType None
 
 Alias /esmond-static /usr/lib/esmond/staticfiles
 <Directory "/usr/lib/esmond/staticfiles">
+Header set Access-Control-Allow-Origin "*"
 AllowOverride None
 <IfVersion >= 2.4>
   Require all granted


### PR DESCRIPTION
Updates the Apache config to allow CORS globally. This is desirable for the perfsonar toolkit as more and more we're making direct, client-side requests to esmond from Javascript, such as in the React charts (rather than querying through a CGI). So far this has led to improved performance and code simplification.

CORS would open the API further, and should not carry security risks. If there are authenticated parts of the API, we might need to treat them differently.

There may be a more fine-grained way of doing this that makes more sense (for instance, it might be desirable to only allow CORS for read-only requests, but I'm not familiar enough with esmond to suggest how that might work). 

