### PR TITLE
Fix an issue where connections errors will get masked

### DIFF
--- a/esmond/api/api_v2.py
+++ b/esmond/api/api_v2.py
@@ -45,7 +45,7 @@ except ConnectionException, e:
     # Check the stack before raising an error - if test_api is 
     # the calling code, we won't need a running db instance.
     mod = inspect.getmodule(inspect.stack()[1][0])
-    if mod and mod.__name__ == 'api.tests.test_api' or 'sphinx.ext.autodoc':
+    if mod and mod.__name__ in ['api.tests.test_api', 'sphinx.ext.autodoc']:
         print '\nUnable to connect - presuming stand-alone testing mode...'
         db = None
     else:


### PR DESCRIPTION
There is a logic error which will cause this code to always assume it's in testing mode.  

The last condition after the last `or` is always True.

This leads to an case where there is not a valid connection to Cassandra so db gets set to None. This is fine for the intended use cases, but means that in production we can end up with a database connection of None leading to all kinds of mayhem.

Here's a fix for that.

@arlake228 Can you verify that this patch looks OK?